### PR TITLE
getreactions: support empty substrates or products

### DIFF
--- a/src/sbml2modelingtoolkit.jl
+++ b/src/sbml2modelingtoolkit.jl
@@ -180,8 +180,10 @@ function getreactions(model)::Array
         kineticformula = eval(Meta.parse(replace(kineticformula, "pow"=>"^")))
         substrates = [eval(Meta.parse(substrate.getSpecies())) for substrate in reaction.getListOfReactants()]
         substoich = [substrate.getStoichiometry() for substrate in reaction.getListOfReactants()]
+        if (length(substrates)==0) substrates = nothing; substoich = nothing end
         products = [eval(Meta.parse(product.getSpecies())) for product in reaction.getListOfProducts()]
         prodstoich = [product.getStoichiometry() for product in reaction.getListOfProducts()]
+        if (length(products)==0) products = nothing; prodstoich = nothing end
         mtkreaction = ModelingToolkit.Reaction(kineticformula, substrates, products, substoich, prodstoich, only_use_rate=true)
         push!(rxs, mtkreaction)
     end

--- a/test/sbml2modelingtoolkit.jl
+++ b/test/sbml2modelingtoolkit.jl
@@ -45,7 +45,7 @@ true_sys = ModelingToolkit.ODESystem(true_eqs)
 prob = sbml2odeproblem(SBML_FILE,(0.0,10.0))
 @test prob.u0 == [1.0, 0.0]  # "Pair{ModelingToolkit.Num,Float64}[A => 1.0,B => 0.0]"
 @test prob.tspan == (0.0, 10.0)
-@test prob.p == [1.0, 0.8, 0.6]  # Todo: try removing the Set() when new ODEproblem version is released.
+@test prob.p == [0.8, 0.6, 1.0]  # Todo: try removing the Set() when new ODEproblem version is released.
 @test_nowarn OrdinaryDiffEq.solve(prob,OrdinaryDiffEq.Tsit5())
 @test_nowarn sbml2odeproblem(SBML_FILE,(0.0,1.0),jac=false)
 


### PR DESCRIPTION
Thanks for the really nice sbml import! There is a problem in `getreactions` if a species is created or degraded in a reaction: In this case `substrates` or `products` have to be `nothing` instead of an array of length 0.